### PR TITLE
fix(package.json): resolve 'nan' find failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Interactive notifications for Windows, from Node",
   "main": "lib/index.js",
   "scripts": {
-    "preinstall": "node ./scripts/preinstall.js && npm run build && node-gyp rebuild",
-    "postinstall": "node ./scripts/postinstall.js",
+    "preinstall": "node ./scripts/preinstall.js && npm run build",
+    "postinstall": "node-gyp rebuild && node ./scripts/postinstall.js",
     "build64": " msbuild .\\InteractiveNotifications.sln /p:Configuration=Release /p:Platform=x64",
     "build86": " msbuild .\\InteractiveNotifications.sln /p:Configuration=Release /p:Platform=x86",
     "build": "npm run build64 && npm run build86"


### PR DESCRIPTION
when install this module as dependency, error like below can occur

```
ode "C:\Users\kwono\AppData\Roaming\nvm\v7.2.1\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node "" rebuild )
module.js:472
    throw err;
    ^

Error: Cannot find module 'nan'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at [eval]:1:1
    at ContextifyScript.Script.runInThisContext (vm.js:26:33)
    at Object.exports.runInThisContext (vm.js:79:17)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:571:32)
    at Immediate.<anonymous> (bootstrap_node.js:383:29)
```

though current `package.json` specifies nan as explicit dependency.

This PR updates lifecycle hook script to resolve this issue, trigger rebuilding `node-gyp` after all dependencies are installed correctly.